### PR TITLE
Cache found files in CoverageStartIncluder and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This class finds the PHP files that should be included in `.htaccess` by setting
 
 The class searches for PHP files that should be included and includes them by keeping a reference to them. By this way, `__destruct` methods of the `CoverageHandler` instances created in `start-coverage.php` files are not called prematurely. They will be called when the script exits. Therefore, coverage data can be collected and dumped properly.
 
-It is enough to create a PHP file and create an instance of `CoverageStarterIncluder` in it to include all `start-coverage.php` files in the project. See `examples/coverage-starter-includer.php` and `examples/.htaccess` for an example.
+It is enough to create a PHP file, create an instance of `CoverageStarterIncluder` in it, and call `includeFiles()` to include all `start-coverage.php` files in the project. See `examples/coverage-starter-includer.php` and `examples/.htaccess` for an example.
 
 ## ReportGenerator
 This class generates HTML and Clover reports from the coverage data dumped by `CoverageHandler`. To use this, create a file named as `generate-report.php` that creates an instance of `ReportGenerator` and calls `generate()` method. An example can be seen in `examples/generate-report.php`. 
@@ -64,4 +64,4 @@ After these are correctly set, you can use PHPStorm's buttons (run, debug, run w
 An example `phpunit` file can be observed in `examples/phpunit`. Simply refer to the phpDoc to learn what the parameters are.
 
 # TODO
-- Write tests
+- Write tests to cover all of the functionality provided by the classes

--- a/app/Coverage/CoverageStarterIncluder.php
+++ b/app/Coverage/CoverageStarterIncluder.php
@@ -40,35 +40,56 @@ class CoverageStarterIncluder {
      */
     private $dumpers = [];
 
+    /** @var string[]|null Paths of the files that should be included. */
+    private $filePaths = null;
+
+    /**
+     * @var string The file that contains the list of to-be-included file paths. The includer will cache the results
+     *      into this file in order not to search for the files again and again.
+     */
+    private $cacheFilePath;
+
+    /** @var bool True if the file paths are retrieved from cache. */
+    private $fromCache = false;
+
     /**
      * CoverageStarterIncluder constructor.
      *
-     * @param string   $rootDirPath
-     * @param string[] $excludedDirParts
-     * @param string   $includeFileName
+     * @param string     $rootDirPath
+     * @param string[]   $excludedDirParts
+     * @param string     $includeFileName
+     * @param null|array $filePaths Absolute paths of the files that should be included. If this is null, the files
+     *                              will be either searched for or read from cache.
      */
     public function __construct(string $rootDirPath, array $excludedDirParts = [],
-                                string $includeFileName = 'start-coverage.php') {
+                                string $includeFileName = 'start-coverage.php', ?array $filePaths = null) {
         $this->rootDirPath      = $rootDirPath;
         $this->excludedDirParts = $excludedDirParts;
         $this->includeFileName  = $includeFileName;
-
-        $this->includeFiles();
+        $this->filePaths        = $filePaths;
     }
 
     /**
      * Finds the files that should be included and includes them.
      */
-    private function includeFiles() {
-        $iterator = $this->createIterator();
+    public function includeFiles() {
+        $filePaths = $this->getFilePaths();
 
         // We have to retrieve the coverage handlers and store them to keep a reference to the variables so that their
         // destruct methods are not called prematurely.
-        foreach (new RecursiveIteratorIterator($iterator) as $file) {
-            /** @var $file SplFileInfo */
-            $this->dumpers[] = include_once($file->getPathname());
+        foreach ($filePaths as $path) {
+            $this->dumpers[] = include_once($path);
+        }
+
+        // If the files were not retrieved from the cache, cache the file paths.
+        if (!$this->fromCache) {
+            $this->cacheFilePaths();
         }
     }
+
+    /*
+     * PRIVATE METHODS
+     */
 
     /**
      * Create the directory iterator that finds the files that should be included.
@@ -135,4 +156,124 @@ class CoverageStarterIncluder {
     private function isValidFile($file): bool {
         return $file->getFilename() == $this->includeFileName;
     }
+
+    /**
+     * Get the file paths from cache, if it exists.
+     *
+     * @return string[]|null Null, if the cache file does not exist. Otherwise, a string array.
+     */
+    private function getFilePathsFromCache() {
+        $cacheFilePath = $this->getCacheFilePath();
+
+        // If no cache file, return null.
+        if (!file_exists($cacheFilePath)) return null;
+
+        $this->fromCache = true;
+
+        $contents = file_get_contents($cacheFilePath);
+        $paths = explode("\n", $contents);
+
+        // Remove empty values
+        return array_filter($paths);
+    }
+
+    /**
+     * Caches the file paths returned by {@link getFilePaths()}
+     */
+    private function cacheFilePaths() {
+        // If there is no cache file path specified, specify one.
+        if (!$this->getCacheFilePath()) {
+            $this->setCacheFilePath(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'include-files.txt');
+        }
+
+        $contents = implode("\n", $this->getFilePaths());
+        file_put_contents($this->getCacheFilePath(), $contents);
+    }
+
+    /*
+     * GETTERS AND SETTERS
+     */
+
+    /**
+     * @return string
+     */
+    public function getRootDirPath(): string {
+        return $this->rootDirPath;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludedDirParts(): array {
+        return $this->excludedDirParts;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIncludeFileName(): string {
+        return $this->includeFileName;
+    }
+
+    /**
+     * @return CoverageHandler[]
+     */
+    public function getDumpers(): array {
+        return $this->dumpers;
+    }
+
+    /**
+     * If {@link $filePaths} is null, finds the paths of the files to be included and assigns them to {@link $filePaths}.
+     *
+     * @return string[] Paths of the files to be included ({@link $filePaths})
+     */
+    public function getFilePaths(): array {
+        // If there are file paths, return them instead of searching for the files.
+        if ($this->filePaths !== null) return $this->filePaths;
+
+        $this->filePaths = $this->getFilePathsFromCache();
+        if ($this->filePaths !== null) return $this->filePaths;
+
+        $this->filePaths = [];
+        $iterator = $this->createIterator();
+
+        // We have to retrieve the coverage handlers and store them to keep a reference to the variables so that their
+        // destruct methods are not called prematurely.
+        foreach (new RecursiveIteratorIterator($iterator) as $file) {
+            /** @var $file SplFileInfo */
+            $this->filePaths[] = $file->getPathname();
+        }
+
+        return $this->filePaths;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCacheFilePath(): ?string {
+        return $this->cacheFilePath;
+    }
+
+    /**
+     * @param string $cacheFilePath
+     * @return $this
+     */
+    public function setCacheFilePath(string $cacheFilePath) {
+        $this->cacheFilePath = $cacheFilePath;
+
+        $dir = dirname($this->cacheFilePath);
+        if (!file_exists($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFromCache(): bool {
+        return $this->fromCache;
+    }
+
 }

--- a/app/Coverage/CoverageStarterIncluder.php
+++ b/app/Coverage/CoverageStarterIncluder.php
@@ -87,6 +87,20 @@ class CoverageStarterIncluder {
         }
     }
 
+    /**
+     * Deletes the cache file so that the files to be included are searched in the given root directory.
+     *
+     * @return bool True if the cache is cleared. Otherwise, false.
+     */
+    public function clearCache() {
+        $cacheFile = $this->getCacheFilePath();
+        if (file_exists($cacheFile)) {
+            @unlink($cacheFile);
+        }
+
+        return !file_exists($cacheFile);
+    }
+
     /*
      * PRIVATE METHODS
      */

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,12 @@
     "ext-json": "*"
   },
   "require-dev": {
+    "phpunit/phpunit": "^8.3"
   },
   "autoload": {
     "psr-4": {
-      "TurgutSaricam\\PHPUnitTools\\": "app/"
+      "TurgutSaricam\\PHPUnitTools\\": "app/",
+      "TurgutSaricam\\PHPUnitToolsTest\\": "tests/"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bdddb30e8786de9fcd3838069e01037",
+    "content-hash": "48c811252745b4ce3b123b5bfadeacbf",
     "packages": [
         {
             "name": "phpunit/php-code-coverage",
@@ -391,14 +391,1152 @@
             "time": "2019-06-13T22:48:21+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-03-17T17:37:11+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2019-08-09T12:45:53+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2019-04-30T17:48:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2019-06-13T12:50:23+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2019-06-07T04:22:29+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "8.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e31cce0cf4499c0ccdbbb211a3280d36ab341e36"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e31cce0cf4499c0ccdbbb211a3280d36ab341e36",
+                "reference": "e31cce0cf4499c0ccdbbb211a3280d36ab341e36",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.0",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2019-08-11T06:56:55+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-07-12T15:12:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2019-02-04T06:01:07+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/06a9a5947f47b3029d76118eb5c22802e5869687",
+                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2019-08-11T12:43:14+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2019-02-01T05:30:01+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-12-25T11:19:39+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "beta",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.2"
+        "php": "~7.2",
+        "ext-json": "*"
     },
     "platform-dev": []
 }

--- a/examples/coverage-starter-includer.php
+++ b/examples/coverage-starter-includer.php
@@ -9,3 +9,5 @@ $includer = new CoverageStarterIncluder(
     ['vendor', 'css', 'js', 'public', 'node_modules'],
     'start-coverage.php'
 );
+
+$includer->includeFiles();

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+!.gitignore
+cache/
+.phpunit.result.cache

--- a/tests/Coverage/CoverageStarterIncluderTest.php
+++ b/tests/Coverage/CoverageStarterIncluderTest.php
@@ -93,6 +93,23 @@ class CoverageStarterIncluderTest extends TestCase {
         $this->assertSame($filePaths2, $filePaths3);
     }
 
+    public function testThatClearCacheMethodClearsTheCache() {
+        $includer1 = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer1->setCacheFilePath($this->getCacheFilePath())->includeFiles();
+        $fromCache1 = $includer1->isFromCache();
+
+        $includer2 = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $isCleared = $includer2
+            ->setCacheFilePath($this->getCacheFilePath())
+            ->clearCache();
+        $includer2->includeFiles();
+        $fromCache2 = $includer2->isFromCache();
+
+        $this->assertFalse($fromCache1);
+        $this->assertTrue($isCleared);
+        $this->assertFalse($fromCache2);
+    }
+
     /*
      * PRIVATE STATIC HELPERS
      */

--- a/tests/Coverage/CoverageStarterIncluderTest.php
+++ b/tests/Coverage/CoverageStarterIncluderTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: turgutsaricam
+ * Date: 23.08.2019
+ * Time: 16:03
+ */
+
+namespace TurgutSaricam\PHPUnitToolsTest\Coverage;
+
+use TurgutSaricam\PHPUnitTools\Coverage\CoverageStarterIncluder;
+use TurgutSaricam\PHPUnitToolsTest\TestCase;
+use TurgutSaricam\PHPUnitToolsTest\TestUtils;
+
+class CoverageStarterIncluderTest extends TestCase {
+
+    /*
+     * SETUP
+     */
+
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        static::deleteCacheDir();
+    }
+
+    /*
+     * TESTS
+     */
+
+    public function testThatCacheFileIsCreatedWhenFilePathIsSpecified() {
+        $includer = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer
+            ->setCacheFilePath($this->getCacheFilePath())
+            ->includeFiles();
+
+        $cacheFile = $includer->getCacheFilePath();
+        $this->assertTrue(file_exists($cacheFile));
+    }
+
+    public function testThatCacheFileContentIsCorrectWhenFilePathIsSpecified() {
+        $includer = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer
+            ->setCacheFilePath($this->getCacheFilePath())
+            ->includeFiles();
+
+        $cacheFile = $includer->getCacheFilePath();
+        $contents = file_get_contents($cacheFile);
+
+        $file1 = $this->getSearchRootDirPath() . '/start-coverage.php';
+        $file2 = $this->getSearchRootDirPath() . '/inner-dir/start-coverage.php';
+        $expected = "{$file1}\n{$file2}";
+
+        $this->assertSame($expected, $contents);
+    }
+
+    public function testThatCacheFileIsCreatedWhenFilePathIsNotSpecified() {
+        $includer = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer->includeFiles();
+
+        $cacheFile = $includer->getCacheFilePath();
+        $this->assertTrue(file_exists($cacheFile));
+
+        @unlink($cacheFile);
+    }
+
+    public function testThatFilePathsAreRetrievedFromCacheFile() {
+        $cacheFilePath = static::getCacheFilePath();
+
+        $includer1 = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer1->setCacheFilePath($cacheFilePath)->includeFiles();
+        $fromCache1 = $includer1->isFromCache();
+        $filePaths1 = $includer1->getFilePaths();
+
+        $includer2 = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer2->setCacheFilePath($cacheFilePath)->includeFiles();
+        $fromCache2 = $includer2->isFromCache();
+        $filePaths2 = $includer2->getFilePaths();
+
+        $includer3 = new CoverageStarterIncluder($this->getSearchRootDirPath());
+        $includer3->setCacheFilePath($cacheFilePath)->includeFiles();
+        $fromCache3 = $includer3->isFromCache();
+        $filePaths3 = $includer3->getFilePaths();
+
+        $this->assertFalse($fromCache1);
+        $this->assertTrue($fromCache2);
+        $this->assertTrue($fromCache3);
+        $this->assertSame($filePaths1, $filePaths2);
+        $this->assertSame($filePaths2, $filePaths3);
+    }
+
+    /*
+     * PRIVATE STATIC HELPERS
+     */
+
+    private static function deleteCacheDir() {
+        @unlink(static::getCacheFilePath());
+
+        if (file_exists(static::getCacheDirPath())) {
+            rmdir(static::getCacheDirPath());
+        }
+    }
+
+    private static function getSearchRootDirPath() {
+        return TestUtils::getTestsDirPath() . '/files';
+    }
+
+    private static function getCacheFilePath() {
+        return static::getCacheDirPath() . '/file-paths.txt';
+    }
+
+    private static function getCacheDirPath() {
+        return TestUtils::getTestsDirPath() . '/files/cache';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: turgutsaricam
+ * Date: 23.08.2019
+ * Time: 16:04
+ */
+
+namespace TurgutSaricam\PHPUnitToolsTest;
+
+
+class TestCase extends \PHPUnit\Framework\TestCase {
+
+}

--- a/tests/TestUtils.php
+++ b/tests/TestUtils.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: turgutsaricam
+ * Date: 23.08.2019
+ * Time: 16:09
+ */
+
+namespace TurgutSaricam\PHPUnitToolsTest;
+
+
+class TestUtils {
+
+    /**
+     * @return string Absolute path of the project directory without a slash in the end.
+     */
+    public static function getProjectDirPath() {
+        return '/usr/src/phpunit-tools';
+    }
+
+    /**
+     * @return string Absolute path of the tests directory
+     */
+    public static function getTestsDirPath() {
+        return static::getProjectDirPath() . '/tests';
+    }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/files/inner-dir/start-coverage.php
+++ b/tests/files/inner-dir/start-coverage.php
@@ -1,0 +1,23 @@
+<?php
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+set_time_limit(60);
+
+$appPath = '/usr/src/phpunit-tools';
+require_once $appPath . '/vendor/autoload.php';
+
+use TurgutSaricam\PHPUnitTools\Coverage\CoverageHandler;
+return new CoverageHandler(
+    CoverageHandler::COVERAGE_TYPE_XDEBUG,
+    'coverageStartHintKey',
+    [
+        $appPath,
+    ],
+    [
+        $appPath . '/vendor',
+        $appPath . '/storage',
+        $appPath . '/views',
+    ],
+    __DIR__ . "/coverages"
+);

--- a/tests/files/start-coverage.php
+++ b/tests/files/start-coverage.php
@@ -1,0 +1,23 @@
+<?php
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+set_time_limit(60);
+
+$appPath = '/usr/src/phpunit-tools';
+require_once $appPath . '/vendor/autoload.php';
+
+use TurgutSaricam\PHPUnitTools\Coverage\CoverageHandler;
+return new CoverageHandler(
+    CoverageHandler::COVERAGE_TYPE_XDEBUG,
+    'coverageStartHintKey',
+    [
+        $appPath,
+    ],
+    [
+        $appPath . '/vendor',
+        $appPath . '/storage',
+        $appPath . '/views',
+    ],
+    __DIR__ . "/coverages"
+);

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<phpunit
+        bootstrap="bootstrap.php"
+        backupGlobals="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+>
+    <testsuites>
+
+        <testsuite name="PHPUnitTools">
+            <directory suffix="Test.php">./</directory>
+        </testsuite>
+
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true" addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../../app</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
Since the coverage starter files should be included in every request,
it is not efficient to search for the files to be included in every
request. This commit caches the found files' paths. By this way, there
is only one search performed.

The files are not included in the constructor method now. They are
included when `includeFiles()` method is called. Hence, example file for
CoverageStarterIncluder is updated as well.

This commit also adds `tests` directory. PHPUnit is added as a dev
dependency. Tests for CoverageStartIncluder is added as well.